### PR TITLE
Claude/fix gmail oauth connection 01 vc bv w mvngev vsz d8 mgw gcf

### DIFF
--- a/src/app/api/gmail/auth/route.ts
+++ b/src/app/api/gmail/auth/route.ts
@@ -18,9 +18,6 @@ export async function GET(request: NextRequest) {
         hasClientSecret: !!process.env.GOOGLE_CLIENT_SECRET,
         redirectUri: process.env.GMAIL_REDIRECT_URI || `${process.env.NEXT_PUBLIC_APP_ORIGIN}/api/gmail/callback`,
         appOrigin: process.env.NEXT_PUBLIC_APP_ORIGIN
-      },
-      oauth2Client: {
-        redirectUri: oauth2Client.redirectUri
       }
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `oauth2Client.redirectUri` from the Gmail auth test endpoint response, leaving only environment details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5daba48fdb05b6c20f31fe19b5aa2d55f6240016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->