### PR TITLE
feat: Migrate deployment platform from Vercel to Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,74 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Testing
+coverage
+.nyc_output
+
+# Next.js
+.next
+out
+
+# Production
+build
+dist
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+*.log
+
+# Local env files
+.env
+.env*.local
+.env.production
+
+# Vercel
+.vercel
+
+# Convex
+.convex
+convex/_generated
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+Thumbs.db
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Documentation
+*.md
+!README.md
+
+# Test files
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+test-*.js
+*-test.js
+
+# CI/CD
+.github
+
+# Backup files
+*.bak
+*.disabled
+
+# Cache
+.pytest_cache
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ yarn-error.log*
 .env
 .env*.local
 
-# Vercel
-.vercel
-
 # Typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 FamilyAI Studio is a premium voice-enabled AI assistant platform with three specialized agent types:
 - **Family Assistant**: Family coordination, scheduling, and member management
-- **Personal Admin**: Email integration, task management, and productivity tools  
+- **Personal Admin**: Email integration, task management, and productivity tools
 - **Student Helper**: Homework tracking, study materials, and academic organization
 
 ## Architecture
@@ -12,7 +12,7 @@ FamilyAI Studio is a premium voice-enabled AI assistant platform with three spec
 - **Authentication**: Clerk
 - **Voice**: OpenAI Realtime API, ElevenLabs, Google TTS, PlayHT
 - **Integrations**: Gmail, Google Calendar, Google Drive
-- **Deployment**: Vercel (recommended)
+- **Deployment**: Render.com (Docker-based)
 
 ## Current Status
 ✅ **Production Ready Features**:
@@ -24,45 +24,25 @@ FamilyAI Studio is a premium voice-enabled AI assistant platform with three spec
 - PWA capabilities
 - Real-time voice commands and tools
 
-## Recommended Deployment Platform: Vercel
+## Deployment Platform: Render.com
 
-### Why Vercel?
-1. **Perfect Next.js Integration**: Built for Next.js with zero configuration
-2. **Edge Functions**: Global CDN with serverless functions
-3. **Automatic Scaling**: Handles traffic spikes automatically
-4. **Environment Variables**: Secure management of API keys
-5. **Preview Deployments**: Test changes before production
-6. **Analytics**: Built-in performance monitoring
-7. **Cost Effective**: Generous free tier, pay-as-you-scale
-
-### Alternative Platforms:
-- **Netlify**: Good for static sites, limited serverless functions
-- **Railway**: Good for full-stack apps, more expensive
-- **AWS Amplify**: More complex setup, enterprise-focused
-- **DigitalOcean App Platform**: Good middle ground, less Next.js optimization
+### Why Render?
+1. **Docker Native**: Full control over build and runtime environment
+2. **Simple Configuration**: Single `render.yaml` file for complete setup
+3. **Automatic Deploys**: Git-based deployments from main branch
+4. **Managed Infrastructure**: Automatic SSL, CDN, and health checks
+5. **Cost Effective**: Generous free tier, predictable pricing
+6. **Next.js Optimized**: Works perfectly with Next.js standalone output
+7. **No Vendor Lock-in**: Standard Docker deployment
 
 ## Deployment Steps
 
-### 1. Environment Setup
-```bash
-# Required environment variables
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
-CLERK_SECRET_KEY=sk_test_...
-NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
-NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
-NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/dashboard
-NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/onboarding
-
-CONVEX_DEPLOYMENT=your-convex-deployment-url
-NEXT_PUBLIC_CONVEX_URL=https://your-convex-deployment.convex.cloud
-
-OPENAI_API_KEY=sk-...
-ELEVENLABS_API_KEY=sk_...
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
-
-NEXT_PUBLIC_BASE_URL=https://your-domain.vercel.app
-```
+### 1. Prerequisites
+- GitHub repository connected to Render
+- Convex account and deployment
+- Clerk account for authentication
+- API keys for OpenAI, ElevenLabs (optional)
+- Google Cloud OAuth credentials
 
 ### 2. Convex Backend Setup
 ```bash
@@ -73,30 +53,70 @@ npm install -g convex
 convex deploy --prod
 
 # Set up environment variables in Convex dashboard
+# Visit: https://dashboard.convex.dev
 ```
 
-### 3. Vercel Deployment
+### 3. Render Deployment
+
+#### Option A: Using Render Dashboard (Recommended)
+1. Go to [https://dashboard.render.com](https://dashboard.render.com)
+2. Click "New +" → "Web Service"
+3. Connect your GitHub repository
+4. Render will auto-detect the `render.yaml` configuration
+5. Review and confirm the settings
+6. Add environment variables (see section below)
+7. Click "Create Web Service"
+
+#### Option B: Using render.yaml (Automatic)
+The repository includes a `render.yaml` file that will be automatically detected by Render. Simply:
+1. Connect your GitHub repo to Render
+2. Render will read the configuration automatically
+3. Set the required environment variables
+4. Deploy!
+
+### 4. Required Environment Variables
+
+Set these in your Render dashboard under "Environment":
+
 ```bash
-# Install Vercel CLI
-npm install -g vercel
+# Clerk Authentication
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
+CLERK_SECRET_KEY=sk_live_...
 
-# Deploy to production
-vercel --prod
+# Convex Backend
+CONVEX_DEPLOYMENT=your-deployment-name
+NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
 
-# Or connect GitHub repo for automatic deployments
+# OpenAI
+OPENAI_API_KEY=sk-...
+NEXT_PUBLIC_OPENAI_API_KEY=sk-...
+
+# ElevenLabs (Optional)
+ELEVENLABS_API_KEY=sk_...
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# Application URL
+NEXT_PUBLIC_BASE_URL=https://your-app.onrender.com
 ```
 
-### 4. Google OAuth Setup
-1. Create Google Cloud Project
-2. Enable Gmail API
-3. Configure OAuth consent screen
-4. Create OAuth 2.0 credentials
-5. Add redirect URIs for production domain
+### 5. Google OAuth Setup
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Create a new project or select existing
+3. Enable Gmail API and Google Calendar API
+4. Configure OAuth consent screen
+5. Create OAuth 2.0 credentials
+6. Add authorized redirect URIs:
+   - `https://your-app.onrender.com/api/auth/callback/google`
+   - `https://your-app.onrender.com/api/gmail/callback`
+7. Copy Client ID and Client Secret to Render environment variables
 
-## File Structure (Cleaned)
+## File Structure
 
 ```
-bpstudio/
+familyai-studio/
 ├── src/
 │   ├── app/                    # Next.js app router
 │   │   ├── api/               # API routes
@@ -116,10 +136,12 @@ bpstudio/
 │   ├── voice_*.ts           # Voice functionality
 │   └── *.ts                 # Feature modules
 ├── public/                   # Static assets
-├── package.json             # Dependencies
-├── next.config.js           # Next.js configuration
-├── tailwind.config.ts       # Styling configuration
-└── tsconfig.json           # TypeScript configuration
+├── Dockerfile               # Docker build configuration
+├── render.yaml             # Render deployment config
+├── package.json            # Dependencies
+├── next.config.js          # Next.js configuration
+├── tailwind.config.ts      # Styling configuration
+└── tsconfig.json          # TypeScript configuration
 ```
 
 ## Key Features
@@ -158,11 +180,12 @@ bpstudio/
 - **ElevenLabs**: Premium voice synthesis
 
 ## Performance Optimizations
-- Edge functions for global performance
-- Image optimization with Next.js
+- Docker multi-stage builds for minimal image size
+- Next.js standalone output for optimal performance
 - Code splitting and lazy loading
 - PWA caching strategies
 - Database indexing for fast queries
+- CDN and edge caching via Render
 
 ## Security Features
 - Clerk authentication with JWT tokens
@@ -170,44 +193,89 @@ bpstudio/
 - Environment variable encryption
 - User data isolation
 - Rate limiting on API endpoints
+- HTTPS enforced by default
 
-## Monitoring & Analytics
-- Vercel Analytics for performance
+## Monitoring & Health Checks
+- Render automatic health checks on `/`
 - Convex dashboard for backend metrics
 - Error tracking and logging
 - User activity monitoring
 - Voice pipeline success rates
 
 ## Scaling Considerations
+- Render auto-scaling based on traffic
 - Convex handles database scaling automatically
-- Vercel edge functions scale globally
-- Voice providers have generous rate limits
-- Stateless architecture for horizontal scaling
+- Stateless Docker containers for horizontal scaling
 - CDN caching for static assets
+- Background job processing via Convex
 
 ## Cost Estimation (Monthly)
-- **Vercel Pro**: $20/month (recommended for production)
+- **Render Starter**: $7/month (512MB RAM, good for testing)
+- **Render Standard**: $25/month (2GB RAM, recommended for production)
 - **Convex**: $25/month (includes database and functions)
 - **OpenAI API**: $50-200/month (depends on usage)
-- **ElevenLabs**: $22/month (Creator plan)
-- **Total**: ~$117-267/month for moderate usage
+- **ElevenLabs**: $22/month (Creator plan, optional)
+- **Total**: ~$104-272/month for production usage
+
+## Troubleshooting
+
+### Build Failures
+- Check Docker build logs in Render dashboard
+- Ensure all environment variables are set
+- Verify `pnpm-lock.yaml` is committed
+
+### Runtime Errors
+- Check application logs in Render dashboard
+- Verify Convex deployment URL is correct
+- Ensure Clerk keys are for production environment
+- Confirm Google OAuth redirect URIs match your domain
+
+### Performance Issues
+- Upgrade to higher Render plan if needed
+- Check Convex query performance in dashboard
+- Review Next.js build output for large bundles
+- Enable Redis caching if necessary
+
+## Continuous Deployment
+
+Render automatically deploys when you push to the `main` branch:
+
+```bash
+git add .
+git commit -m "Deploy to production"
+git push origin main
+```
+
+Render will:
+1. Detect the push to main
+2. Build the Docker image
+3. Run health checks
+4. Deploy with zero downtime
+5. Rollback automatically if health checks fail
 
 ## Support & Maintenance
 - Automated deployments via GitHub
-- Environment variable management
+- Environment variable management in Render dashboard
 - Database backups via Convex
 - Error monitoring and alerts
 - Performance optimization tools
 
 ## Next Steps
-1. Set up production environment variables
-2. Deploy Convex backend to production
-3. Configure Google OAuth for production domain
-4. Deploy to Vercel with custom domain
-5. Set up monitoring and analytics
-6. Test all integrations in production
-7. Launch with confidence!
+1. ✅ Connect GitHub repository to Render
+2. ✅ Set up Convex backend in production
+3. ✅ Configure all environment variables
+4. ✅ Set up Google OAuth with production domain
+5. ✅ Deploy and verify health checks pass
+6. ✅ Test all integrations in production
+7. ✅ (Optional) Add custom domain
+8. ✅ Launch with confidence!
 
 ---
 
-**Your FamilyAI Studio is ready for production deployment on Vercel!** 🚀
+**Your FamilyAI Studio is ready for production deployment on Render!** 🚀
+
+## Additional Resources
+- [Render Documentation](https://render.com/docs)
+- [Next.js Deployment Guide](https://nextjs.org/docs/deployment)
+- [Convex Production Best Practices](https://docs.convex.dev/production)
+- [Clerk Production Checklist](https://clerk.com/docs/deployments/production-checklist)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# FamilyAI Studio - Production Dockerfile for Render
+FROM node:18-alpine AS base
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Dependencies stage
+FROM base AS deps
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile --prod=false
+
+# Builder stage
+FROM base AS builder
+WORKDIR /app
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Set environment to production
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build the application
+RUN pnpm build
+
+# Production stage
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Copy necessary files
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+# Set correct permissions
+RUN chown -R nextjs:nodejs /app
+
+# Switch to non-root user
+USER nextjs
+
+# Expose port
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Start the application
+CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   experimental: {
     esmExternals: 'loose',
     serverComponentsExternalPackages: ['pdf-parse', 'mammoth']

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy",
     "convex:deploy:prod": "convex deploy --prod",
-    "deploy:vercel": "vercel --prod",
-    "deploy:full": "pnpm build && pnpm convex:deploy:prod && pnpm deploy:vercel"
+    "deploy:full": "pnpm build && pnpm convex:deploy:prod"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.1",
@@ -37,7 +36,6 @@
     "@tanstack/react-query": "^5.17.9",
     "@types/nodemailer": "^7.0.1",
     "@types/pdf-parse": "^1.1.5",
-    "@vercel/sdk": "^1.10.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.26.2",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,44 @@
+services:
+  - type: web
+    name: familyai-studio
+    env: docker
+    dockerfilePath: ./Dockerfile
+    plan: starter
+    region: oregon
+    branch: main
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NEXT_TELEMETRY_DISABLED
+        value: 1
+      - key: PORT
+        value: 3000
+      - key: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+        sync: false
+      - key: CLERK_SECRET_KEY
+        sync: false
+      - key: NEXT_PUBLIC_CLERK_SIGN_IN_URL
+        value: /sign-in
+      - key: NEXT_PUBLIC_CLERK_SIGN_UP_URL
+        value: /sign-up
+      - key: NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
+        value: /dashboard
+      - key: NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL
+        value: /onboarding
+      - key: CONVEX_DEPLOYMENT
+        sync: false
+      - key: NEXT_PUBLIC_CONVEX_URL
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: NEXT_PUBLIC_OPENAI_API_KEY
+        sync: false
+      - key: ELEVENLABS_API_KEY
+        sync: false
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false
+      - key: NEXT_PUBLIC_BASE_URL
+        sync: false

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,10 +5,10 @@ const fs = require('fs');
 const path = require('path');
 
 // Check if we're in production environment
-const isProduction = process.env.VERCEL_ENV === 'production';
+const isProduction = process.env.NODE_ENV === 'production';
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
 
-console.log('🔍 Build Environment:', process.env.VERCEL_ENV || 'local');
+console.log('🔍 Build Environment:', process.env.NODE_ENV || 'local');
 console.log('📦 Production Build:', isProduction);
 
 try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches deployment from Vercel to Render using a Docker-based setup, updates build/config for standalone Next.js, and revises docs and scripts accordingly.
> 
> - **Infrastructure / Deployment**
>   - Add `Dockerfile` for multi-stage production build and non-root runtime.
>   - Add `render.yaml` with web service config, health check (`/`), and required env vars (incl. `NEXT_PUBLIC_OPENAI_API_KEY`).
>   - Add `.dockerignore`; update `.gitignore` (remove Vercel-specific ignore, tidy entries).
>   - Set Next.js `output: 'standalone'` in `next.config.js` for Docker/Render.
> - **Build & Scripts**
>   - Update `scripts/build.js` to use `NODE_ENV` (not `VERCEL_ENV`), deploy Convex only in production, and codegen in non-prod; logs adjusted.
>   - Remove Vercel deploy script and `@vercel/sdk` from `package.json`; simplify `deploy:full`.
> - **Documentation**
>   - Rewrite `DEPLOYMENT_GUIDE.md` to focus on Render deployment (prereqs, env vars, OAuth setup, troubleshooting, scaling, costs, and file structure).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ec7bea0fa02344c9bf5beff9386184410371461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->