### PR TITLE
chore: Update pnpm-lock.yaml after removing @vercel/sdk dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 0.0.88(@auth/core@0.37.4(nodemailer@7.0.10))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@convex-dev/react-query':
         specifier: ^0.0.0-alpha.5
-        version: 0.0.0-alpha.11(@tanstack/react-query@5.90.5(react@18.3.1))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(nodemailer@7.0.10)(react@18.3.1)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.0.0-alpha.11(@tanstack/react-query@5.90.5(react@18.3.1))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(nodemailer@7.0.10)(react@18.3.1)(typescript@5.9.3)(zod@4.1.12)
       '@openai/agents':
         specifier: ^0.2.1
-        version: 0.2.1(ws@8.18.3)(zod@3.25.76)
+        version: 0.2.1(ws@8.18.3)(zod@4.1.12)
       '@radix-ui/react-dialog':
         specifier: ^1.0.5
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -59,9 +59,6 @@ importers:
       '@types/pdf-parse':
         specifier: ^1.1.5
         version: 1.1.5
-      '@vercel/sdk':
-        specifier: ^1.10.4
-        version: 1.16.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -94,7 +91,7 @@ importers:
         version: 7.0.10
       openai:
         specifier: ^4.24.7
-        version: 4.104.0(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(ws@8.18.3)(zod@4.1.12)
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.3
@@ -2136,15 +2133,6 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
-
-  '@vercel/sdk@1.16.1':
-    resolution: {integrity: sha512-8aAMcGpX1Y+yJ7LBPgUvGQQOTsXyHJyO1B8alh1mOo5G875in6GnUDQg7hFdig3NPWOhRHO+lt3XXdSsMqkzGQ==}
-    hasBin: true
-    peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.5.0 <1.10.0'
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -5419,13 +5407,13 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@convex-dev/react-query@0.0.0-alpha.11(@tanstack/react-query@5.90.5(react@18.3.1))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(nodemailer@7.0.10)(react@18.3.1)(typescript@5.9.3)(zod@3.25.76)':
+  '@convex-dev/react-query@0.0.0-alpha.11(@tanstack/react-query@5.90.5(react@18.3.1))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(nodemailer@7.0.10)(react@18.3.1)(typescript@5.9.3)(zod@4.1.12)':
     dependencies:
       '@auth/core': 0.37.4(nodemailer@7.0.10)
       '@convex-dev/auth': 0.0.83(@auth/core@0.37.4(nodemailer@7.0.10))(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query': 5.90.5(react@18.3.1)
       convex: 1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1)
-      convex-helpers: 0.1.104(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.104(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(zod@4.1.12)
     transitivePeerDependencies:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'
@@ -5918,47 +5906,47 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@openai/agents-core@0.2.1(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-core@0.2.1(ws@8.18.3)(zod@4.1.12)':
     dependencies:
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.3)(zod@3.25.76)
+      openai: 6.10.0(ws@8.18.3)(zod@4.1.12)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.20.2
-      zod: 3.25.76
+      zod: 4.1.12
     transitivePeerDependencies:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.2.1(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents-openai@0.2.1(ws@8.18.3)(zod@4.1.12)':
     dependencies:
-      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@4.1.12)
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.3)(zod@3.25.76)
-      zod: 3.25.76
+      openai: 6.10.0(ws@8.18.3)(zod@4.1.12)
+      zod: 4.1.12
     transitivePeerDependencies:
       - supports-color
       - ws
 
-  '@openai/agents-realtime@0.2.1(zod@3.25.76)':
+  '@openai/agents-realtime@0.2.1(zod@4.1.12)':
     dependencies:
-      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@4.1.12)
       '@types/ws': 8.18.1
       debug: 4.4.3
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.1.12
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.2.1(ws@8.18.3)(zod@3.25.76)':
+  '@openai/agents@0.2.1(ws@8.18.3)(zod@4.1.12)':
     dependencies:
-      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-openai': 0.2.1(ws@8.18.3)(zod@3.25.76)
-      '@openai/agents-realtime': 0.2.1(zod@3.25.76)
+      '@openai/agents-core': 0.2.1(ws@8.18.3)(zod@4.1.12)
+      '@openai/agents-openai': 0.2.1(ws@8.18.3)(zod@4.1.12)
+      '@openai/agents-realtime': 0.2.1(zod@4.1.12)
       debug: 4.4.3
-      openai: 6.10.0(ws@8.18.3)(zod@3.25.76)
-      zod: 3.25.76
+      openai: 6.10.0(ws@8.18.3)(zod@4.1.12)
+      zod: 4.1.12
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7050,10 +7038,6 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/sdk@1.16.1':
-    dependencies:
-      zod: 4.1.12
-
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@20.19.24))':
     dependencies:
       '@babel/core': 7.28.5
@@ -7442,13 +7426,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-helpers@0.1.104(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(zod@3.25.76):
+  convex-helpers@0.1.104(convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(zod@4.1.12):
     dependencies:
       convex: 1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       react: 18.3.1
       typescript: 5.9.3
-      zod: 3.25.76
+      zod: 4.1.12
 
   convex@1.28.0(@clerk/clerk-react@4.32.5(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -9013,7 +8997,7 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  openai@4.104.0(ws@8.18.3)(zod@3.25.76):
+  openai@4.104.0(ws@8.18.3)(zod@4.1.12):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -9024,14 +9008,14 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.1.12
     transitivePeerDependencies:
       - encoding
 
-  openai@6.10.0(ws@8.18.3)(zod@3.25.76):
+  openai@6.10.0(ws@8.18.3)(zod@4.1.12):
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.1.12
 
   option@0.2.4: {}
 
@@ -10145,6 +10129,7 @@ snapshots:
       zod: 3.25.76
     optional: true
 
-  zod@3.25.76: {}
+  zod@3.25.76:
+    optional: true
 
   zod@4.1.12: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates pnpm-lock.yaml to drop @vercel/sdk and standardize transitive deps to zod 4.1.12 across OpenAI/agents and Convex-related packages.
> 
> - **Dependencies (lockfile only)**:
>   - Remove `@vercel/sdk` and its transitive references.
>   - Align `zod` to `4.1.12` across `openai`, `@openai/agents*`, and `convex-helpers`/`@convex-dev/react-query` entries.
>   - Update related peer/transitive metadata to reflect the `zod` bump; no application code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30d367e9eac42b106cde4d9bea870382fdd614dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->